### PR TITLE
feat: Pretendard 폰트 적용

### DIFF
--- a/_config.next.yml
+++ b/_config.next.yml
@@ -19,7 +19,7 @@ minify: false
 # Define custom file paths.
 # Create your custom files in site directory `source/_data` and uncomment needed files below.
 custom_file_path:
-  #head: source/_data/head.njk
+  head: source/_data/head.njk
   #header: source/_data/header.njk
   #sidebar: source/_data/sidebar.njk
   #postMeta: source/_data/post-meta.njk
@@ -28,7 +28,7 @@ custom_file_path:
   #bodyEnd: source/_data/body-end.njk
   #variable: source/_data/variables.styl
   #mixin: source/_data/mixins.styl
-  #style: source/_data/styles.styl
+  style: source/_data/styles.styl
 
 
 # ---------------------------------------------------------------
@@ -412,7 +412,9 @@ github_banner:
 # ---------------------------------------------------------------
 
 font:
-  enable: true
+  # Pretendard 폰트는 source/_data/head.njk와 styles.styl에서 로드
+  # 굵기 조절: source/_data/styles.styl의 :root 변수 수정
+  enable: false
 
   # Uri of fonts host, e.g. https://fonts.googleapis.com (Default).
   host:
@@ -425,19 +427,19 @@ font:
   # Global font settings used for all elements inside <body>.
   global:
     external: true
-    family: Nanum Gothic
+    family:
     size:
 
   # Font settings for site title (.site-title).
   title:
     external: true
-    family: Lato
+    family:
     size:
 
   # Font settings for headlines (<h1> to <h6>).
   headings:
     external: true
-    family: Noto Sans KR
+    family:
     size:
 
   # Font settings for posts (.post-body).

--- a/source/_data/head.njk
+++ b/source/_data/head.njk
@@ -1,0 +1,1 @@
+<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />

--- a/source/_data/styles.styl
+++ b/source/_data/styles.styl
@@ -1,0 +1,34 @@
+// Pretendard 폰트 설정
+// 
+// 폰트 굵기 조절 방법:
+// - font-weight 값을 변경 (100 ~ 900)
+// - 100: Thin, 200: ExtraLight, 300: Light, 400: Regular
+// - 500: Medium, 600: SemiBold, 700: Bold, 800: ExtraBold, 900: Black
+//
+// 예시: 본문을 더 가늘게 하려면 --font-weight-body를 300으로 변경
+
+:root
+  // 폰트 굵기 변수 (여기서 조절)
+  --font-weight-body: 400        // 본문 기본 굵기
+  --font-weight-heading: 600     // 제목 굵기
+  --font-weight-bold: 700        // 강조(bold) 굵기
+  --font-weight-code: 400        // 코드 굵기
+
+// 전역 폰트 적용
+body
+  font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif
+  font-weight: var(--font-weight-body)
+
+// 제목
+h1, h2, h3, h4, h5, h6
+.post-title, .site-title
+  font-family: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", sans-serif
+  font-weight: var(--font-weight-heading)
+
+// 강조
+strong, b
+  font-weight: var(--font-weight-bold)
+
+// 코드
+code, pre
+  font-weight: var(--font-weight-code)


### PR DESCRIPTION
## 변경 사항

### Pretendard Variable 웹폰트 적용
- jsDelivr CDN에서 로드 (dynamic subset - 사용하는 글자만 로드)
- 기존 Google Fonts (Nanum Gothic, Noto Sans KR, Lato) 비활성화

### 폰트 굵기 설정

`source/_data/styles.styl`의 `:root` 변수에서 조절:

```stylus
:root
  --font-weight-body: 400        // 본문 기본 굵기
  --font-weight-heading: 600     // 제목 굵기
  --font-weight-bold: 700        // 강조(bold) 굵기
  --font-weight-code: 400        // 코드 굵기
```

### 사용 가능한 굵기 값
| 값 | 이름 |
|---|---|
| 100 | Thin |
| 200 | ExtraLight |
| 300 | Light |
| 400 | Regular |
| 500 | Medium |
| 600 | SemiBold |
| 700 | Bold |
| 800 | ExtraBold |
| 900 | Black |

Variable 폰트라서 100~900 사이 어떤 값이든 가능 (예: 350, 450 등)